### PR TITLE
Update variable types

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,45 +1,45 @@
 variable "load_balancer_id" {
-  type        = "string"
+  type        = string
   description = "ALB ID"
 }
 
 variable "target_group_id" {
-  type        = "string"
+  type        = string
   description = "Target Group ID"
 }
 
 variable "prefix" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Alarm Name Prefix"
 }
 
 variable "response_time_threshold" {
-  type        = "string"
+  type        = string
   default     = "50"
   description = "The average number of milliseconds that requests should complete within."
 }
 
 variable "evaluation_period" {
-  type        = "string"
+  type        = string
   default     = "5"
   description = "The evaluation period over which to use when triggering alarms."
 }
 
 variable "statistic_period" {
-  type        = "string"
+  type        = string
   default     = "60"
   description = "The number of seconds that make each statistic period."
 }
 
 variable "actions_alarm" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "A list of actions to take when alarms are triggered. Will likely be an SNS topic for event distribution."
 }
 
 variable "actions_ok" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "A list of actions to take when alarms are cleared. Will likely be an SNS topic for event distribution."
 }


### PR DESCRIPTION
Eliminates the warning: 
```
Warning: Quoted type constraints are deprecated

  on .terraform/modules/aws-alb-alarms/variables.tf line 2, in variable "load_balancer_id":
   2:   type        = "string"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "string".
```