### PR TITLE
TargetResponseTime is in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module "aws-alb-alarms" {
 | evaluation_period         | The evaluation period over which to use when triggering alarms.                                          | `string` | `"5"`   |    no    |
 | load_balancer_id          | ALB ID                                                                                                   | `string` | n/a     |   yes    |
 | prefix                    | Alarm Name Prefix                                                                                        | `string` | `""`    |    no    |
-| response_time_threshold   | The average number of seconds that requests should complete within.                                      | `string` | `"1"`   |    no    |
+| response_time_threshold   | The average number of seconds that requests should complete within.                                      | `string` | `"0.05"`|    no    |
 | unhealthy_hosts_threshold | The number of unhealthy hosts.                                                                           | `string` | `"0"`   |    no    |
 | healthy_hosts_threshold   | The number of healthy hosts.                                                                             | `string` | `"0"`   |    no    |
 | statistic_period          | The number of seconds that make each statistic period.                                                   | `string` | `"60"`  |    no    |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ module "aws-alb-alarms" {
 | evaluation_period         | The evaluation period over which to use when triggering alarms.                                          | `string` | `"5"`   |    no    |
 | load_balancer_id          | ALB ID                                                                                                   | `string` | n/a     |   yes    |
 | prefix                    | Alarm Name Prefix                                                                                        | `string` | `""`    |    no    |
-| response_time_threshold   | The average number of milliseconds that requests should complete within.                                 | `string` | `"50"`  |    no    |
+| response_time_threshold   | The average number of seconds that requests should complete within.                                      | `string` | `"1"`   |    no    |
 | unhealthy_hosts_threshold | The number of unhealthy hosts.                                                                           | `string` | `"0"`   |    no    |
 | healthy_hosts_threshold   | The number of healthy hosts.                                                                             | `string` | `"0"`   |    no    |
 | statistic_period          | The number of seconds that make each statistic period.                                                   | `string` | `"60"`  |    no    |

--- a/variables.tf
+++ b/variables.tf
@@ -16,8 +16,8 @@ variable "prefix" {
 
 variable "response_time_threshold" {
   type        = string
-  default     = "50"
-  description = "The average number of milliseconds that requests should complete within."
+  default     = "1"
+  description = "The average number of seconds that requests should complete within."
 }
 
 variable "unhealthy_hosts_threshold" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "prefix" {
 
 variable "response_time_threshold" {
   type        = string
-  default     = "1"
+  default     = "0.05"
   description = "The average number of seconds that requests should complete within."
 }
 


### PR DESCRIPTION
`TargetResponseTime` is in seconds not milliseconds:

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html