### PR TITLE
Added variables to configure the threshold for 5xx errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ module "aws-alb-alarms" {
 | response_time_threshold   | The average number of milliseconds that requests should complete within.                                 | `string` | `"50"`  |    no    |
 | unhealthy_hosts_threshold | The number of unhealthy hosts.                                                                           | `string` | `"0"`   |    no    |
 | healthy_hosts_threshold   | The number of healthy hosts.                                                                             | `string` | `"0"`   |    no    |
+| httpcode_target_5xx_count_threshold | The number of target 5xx errors to trigger the alarm                                           | `string` | `"0"`   |    no    |
+| httpcode_lb_5xx_count_threshold | The number of lb 5xx errors to trigger the alarm                                                   | `string` | `"0"`   |    no    |
 | statistic_period          | The number of seconds that make each statistic period.                                                   | `string` | `"60"`  |    no    |
 | target_group_id           | Target Group ID                                                                                          | `string` | n/a     |   yes    |
 

--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
   namespace           = "AWS/ApplicationELB"
   period              = var.statistic_period
   statistic           = "Sum"
-  threshold           = "0"
+  threshold           = var.httpcode_target_5xx_count_threshold
   alarm_description   = "Average API 5XX target group error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_lb_5xx_count" {
   namespace           = "AWS/ApplicationELB"
   period              = var.statistic_period
   statistic           = "Sum"
-  threshold           = "0"
+  threshold           = var.httpcode_lb_5xx_count_threshold
   alarm_description   = "Average API 5XX load balancer error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_target_5xx_count" {
   period              = var.statistic_period
   statistic           = "Sum"
   threshold           = var.httpcode_target_5xx_count_threshold
+  treat_missing_data = "notBreaching"
   alarm_description   = "Average API 5XX target group error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok
@@ -26,6 +27,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_lb_5xx_count" {
   period              = var.statistic_period
   statistic           = "Sum"
   threshold           = var.httpcode_lb_5xx_count_threshold
+  treat_missing_data = "notBreaching"
   alarm_description   = "Average API 5XX load balancer error code count is too high"
   alarm_actions       = var.actions_alarm
   ok_actions          = var.actions_ok

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,18 @@ variable "healthy_hosts_threshold" {
   description = "The number of healthy hosts."
 }
 
+variable "httpcode_target_5xx_count_threshold" {
+  type        = string
+  default     = "0"
+  description = "The threshold for target 5xx errors."
+}
+
+variable "httpcode_lb_5xx_count_threshold" {
+  type        = string
+  default     = "0"
+  description = "The number of 5xx HTTP codes that should be returned."
+}
+
 variable "evaluation_period" {
   type        = string
   default     = "5"


### PR DESCRIPTION
I've added some variables to control the 5xx threshold errors. These changes are fully BC.

This can be useful when dealing with some legacy applications that yield a lot of 5xx errors and make the alarm go off continuously.